### PR TITLE
new factory method introduced in PropertiesBasedSettings

### DIFF
--- a/FcmJava/fcmjava-client/src/main/java/de/bytefish/fcmjava/client/settings/PropertiesBasedSettings.java
+++ b/FcmJava/fcmjava-client/src/main/java/de/bytefish/fcmjava/client/settings/PropertiesBasedSettings.java
@@ -10,7 +10,6 @@ import de.bytefish.fcmjava.http.options.IFcmClientSettings;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystems;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Properties;
 
@@ -22,7 +21,7 @@ public class PropertiesBasedSettings implements IFcmClientSettings {
     private final String fcmUrl;
     private final String fcmApiKey;
 
-    protected PropertiesBasedSettings(Properties properties) {
+    private PropertiesBasedSettings(Properties properties) {
         fcmUrl = properties.getProperty("fcm.api.url", Constants.FCM_URL);
         fcmApiKey = properties.getProperty("fcm.api.key");
     }
@@ -76,4 +75,15 @@ public class PropertiesBasedSettings implements IFcmClientSettings {
 
         return new PropertiesBasedSettings(properties);
     }
+
+    /**
+     * Reads the properties from a Properties object.
+     *
+     * @param properties Properties instance
+     * @return Initialized Client Settings
+     */
+    public static PropertiesBasedSettings createFromProperties(Properties properties) {
+        return new PropertiesBasedSettings(properties);
+    }
+
 }


### PR DESCRIPTION
Added a new factory method in `PropertiesBasedSettings `to allow creation of instances directly from a `Properties `objetct. Also the constructor was changed to private access, for better encapsulation.